### PR TITLE
Fix initialization when DOMContentLoaded already fired

### DIFF
--- a/app.js
+++ b/app.js
@@ -1413,7 +1413,7 @@ function saveSettings() {
 // Event listeners e inizializzazione
 // ============================
 
-document.addEventListener('DOMContentLoaded', () => {
+function initApp() {
     // Navigazione principale
     document.querySelectorAll('.nav-button').forEach(button => {
         button.addEventListener('click', () => {
@@ -1529,7 +1529,13 @@ document.addEventListener('DOMContentLoaded', () => {
     if (window.renderMathInElement) {
         renderMathInElement(document.body);
     }
-});
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initApp);
+} else {
+    initApp();
+}
 
 function setActiveTopic(topicKey) {
     currentTopic = topicKey;


### PR DESCRIPTION
## Summary
- wrap the UI initialization logic in an `initApp` function
- ensure initialization runs immediately if the DOM is already parsed, or waits for DOMContentLoaded otherwise

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e80cfc81c4832f9635250fa992ed9c